### PR TITLE
s/rustc_serialize/serde/g

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "constable"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Joshua Miller <jsmiller@uchicago.edu>"]
 
 [dependencies]
-bincode = "*"
-rustc-serialize = "^0.3"
-quick-error = "*"
+bincode = "0.8.0"
+quick-error = "1.2.0"
+serde = "1.0.11"
+serde_derive = "1.0.11"

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,6 +1,6 @@
 use datatypes::DataType;
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Column {
     pub name: String,
     pub datatype: DataType,

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -1,6 +1,6 @@
 //! Core Constable data types
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum DataType {
     Text,
     BigInteger,
@@ -9,7 +9,7 @@ pub enum DataType {
     Boolean,
 }
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum DataValue {
     Text(Option<String>),
     BigInteger(Option<i64>),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,8 +7,6 @@ quick_error! {
         /// IO Error
         Io(err: IOError) { from() }
         /// Encoding Error
-        Encoding(err: bincode::rustc_serialize::EncodingError) { from() }
-        /// Decoding Error
-        Decoding(err: bincode::rustc_serialize::DecodingError) { from() }
+        Encoding(err: bincode::Error) { from() }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-#[macro_use]
-extern crate quick_error;
+#[macro_use] extern crate quick_error;
+#[macro_use] extern crate serde_derive;
+
 extern crate bincode;
-extern crate rustc_serialize;
+
 
 pub mod column;
 pub mod datatypes;

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,6 @@
 use datatypes::DataValue;
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Row {
     pub id: u64,
     pub deleted: bool,


### PR DESCRIPTION
Should address #4 by replacing `rustc_serialize` with `serde` all over. It looks like bincode ripped out the rustc backend. Also pins dependencies and silences an unhandled IO error. I bumped the patch version, since it may have some unintended side effects. ¯\\_(ツ)_/¯

@millerjs 